### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,137 +1,111 @@
-# Run Selenium Tests With NemoJS — TestMu AI (Formerly LambdaTest)
-
-![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
+# Run Selenium Tests with NemoJS on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/nemo"><img src="https://img.shields.io/npm/v/nemo.svg?style=for-the-badge&labelColor=000000" alt="Nemo version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to use NemoJS framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
+## Getting Started
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-## Table of Contents
+With TestMu AI (Formerly LambdaTest), you can run NemoJS tests with Selenium across real browsers and operating systems. This sample shows how to configure NemoJS Selenium tests to run on the TestMu AI cloud.
 
-* [Pre-requisites](#pre-requisites)
-* [Running The Single Test Case With NemoJS](#running-the-single-test-case-with-nemojs)
-* [Running The Parallel Tests With NemoJS](#running-the-parallel-tests-with-nemojs)
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-## Pre-requisites
+### Prerequisites
 
-Before starting running your Selenium tests with NemoJS, ensure you have the following things configured.
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-1. Make sure you have NodeJS installed. You can install it from the official [NodeJS website](https://nodejs.org/en/#home-downloadhead). You can also install NodeJS by running the following command in the terminal.
+### Setup
 
-``` js
-$ brew install node
-```
+Clone and install dependencies:
 
-2. Clone the repo.
-
-``` js
-git clone https://github.com/LambdaTest/Nemo-Lambdatest-sample.git
-cd Nemo-Lambdatest-sample
-```
-
-3. Install the dependencies by executing the following command.
-
-``` js
+```bash
+git clone https://github.com/LambdaTest/Nemo-Lambdatest-sample && cd Nemo-Lambdatest-sample
 npm install
 ```
 
-4. To run your Selenium tests with NemoJS, you would need to set your TestMu AI username and access key in the environment variables. To get it, visit [Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample) and click on the Key button from the top-right.
+Set your credentials as environment variables.
 
-**For Windows:**
+**macOS / Linux:**
 
-``` js
-set LT_USERNAME="YOUR_LAMBDATEST_USERNAME"
-set LT_ACCESS_KEY="YOUR_LAMBDATEST_ACCESS_KEY"
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-**For Mac/Linux:**
+**Windows:**
 
-``` js
-export LT_USERNAME="YOUR_LAMBDATEST_USERNAME"
-export LT_ACCESS_KEY="YOUR_LAMBDATEST_ACCESS_KEY"
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-5. Set the environment variables in `nemo.config.js` file with your TestMu AI Username and Access Key.
+### Run tests
 
-## Running The Single Test Case With NemoJS
-
-**Test Scenario:** To run your single test case with NemoJS on TestMu AI, let’s understand our test case scenario, the below Nemo.js automation script will test a sample to-do list app. The code marks two list items as done, adds a list item, and then outputs the total number of pending items. Check out the [nemo.test.js](https://github.com/LambdaTest/Nemo-TestMu AI-sample/blob/master/test/functional/nemo.test.js) file to run your first sample test. 
-
-To run the single test, execute the below command in the terminal.
-
-``` js
+```bash
 npx nemo -P chrome
 ```
 
-## Running The Parallel Tests With NemoJS
+View results on your TestMu AI dashboard.
 
-**Test Scenario:** In this code, we will test our Sample to-do app in three browser versions and operating systems. Check out the [nemo.config.js](https://github.com/LambdaTest/Nemo-TestMu AI-sample/blob/master/nemo.config.js) file to run your first sample test. 
+### Local testing with TestMu AI Tunnel
 
-Now run the below command to run the parallel tests.
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-``` js
-npx nemo -P chrome,chrome_2,firefox
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
+```js
+tunnel: true,
 ```
 
+## Contributions
 
-## Documentation & Resources :books:
- 
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Nemo version.
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)    
+## TestMu AI (Formerly LambdaTest) Community
 
-## TestMu AI Community :busts_in_silhouette:
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-## What's New At TestMu AI ❓
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-## 🚀 LambdaTest is Now TestMu AI
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-### 🔄 Our Rebrand Journey
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+### How LambdaTest Evolved into TestMu AI
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-### 🔭 Explore TestMu AI
+## Support
 
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Run Selenium Tests With NemoJS On LambdaTest
+# Run Selenium Tests With NemoJS — TestMu AI (Formerly LambdaTest)
 
 ![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use NemoJS framework to configure and run your JavaScript automation testing scripts on the LambdaTest platform*
+*Learn how to use NemoJS framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
 
@@ -52,7 +52,7 @@ cd Nemo-Lambdatest-sample
 npm install
 ```
 
-4. To run your Selenium tests with NemoJS, you would need to set your LambdaTest username and access key in the environment variables. To get it, visit [Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample) and click on the Key button from the top-right.
+4. To run your Selenium tests with NemoJS, you would need to set your TestMu AI username and access key in the environment variables. To get it, visit [Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample) and click on the Key button from the top-right.
 
 **For Windows:**
 
@@ -68,11 +68,11 @@ export LT_USERNAME="YOUR_LAMBDATEST_USERNAME"
 export LT_ACCESS_KEY="YOUR_LAMBDATEST_ACCESS_KEY"
 ```
 
-5. Set the environment variables in `nemo.config.js` file with your LambdaTest Username and Access Key.
+5. Set the environment variables in `nemo.config.js` file with your TestMu AI Username and Access Key.
 
 ## Running The Single Test Case With NemoJS
 
-**Test Scenario:** To run your single test case with NemoJS on LambdaTest, let’s understand our test case scenario, the below Nemo.js automation script will test a sample to-do list app. The code marks two list items as done, adds a list item, and then outputs the total number of pending items. Check out the [nemo.test.js](https://github.com/LambdaTest/Nemo-Lambdatest-sample/blob/master/test/functional/nemo.test.js) file to run your first sample test. 
+**Test Scenario:** To run your single test case with NemoJS on TestMu AI, let’s understand our test case scenario, the below Nemo.js automation script will test a sample to-do list app. The code marks two list items as done, adds a list item, and then outputs the total number of pending items. Check out the [nemo.test.js](https://github.com/LambdaTest/Nemo-TestMu AI-sample/blob/master/test/functional/nemo.test.js) file to run your first sample test. 
 
 To run the single test, execute the below command in the terminal.
 
@@ -82,7 +82,7 @@ npx nemo -P chrome
 
 ## Running The Parallel Tests With NemoJS
 
-**Test Scenario:** In this code, we will test our Sample to-do app in three browser versions and operating systems. Check out the [nemo.config.js](https://github.com/LambdaTest/Nemo-Lambdatest-sample/blob/master/nemo.config.js) file to run your first sample test. 
+**Test Scenario:** In this code, we will test our Sample to-do app in three browser versions and operating systems. Check out the [nemo.config.js](https://github.com/LambdaTest/Nemo-TestMu AI-sample/blob/master/nemo.config.js) file to run your first sample test. 
 
 Now run the below command to run the parallel tests.
 
@@ -93,42 +93,35 @@ npx nemo -P chrome,chrome_2,firefox
 
 ## Documentation & Resources :books:
  
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-TestMu AI-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-      
-## We are here to help you :headphones:
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=Nemo-Lambdatest-sample)
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -117,11 +117,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code